### PR TITLE
Update coding_guidelines.md

### DIFF
--- a/documentation/coding_guidelines.md
+++ b/documentation/coding_guidelines.md
@@ -267,7 +267,7 @@ impl Foo {
 
 #[cfg(test)]
 mod tests {
-  #test
+  #[test]
   fn verify_magic_number() {
     assert_eq!(Foo::magic_number(), 42);
   }


### PR DESCRIPTION
In the unit tests example,  #test to changed to #[test]. The # should be #[ to correctly denote the test attribute in Rust.

### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
